### PR TITLE
Move config from disinfo ops to ota ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vagrant
+vault.key
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,173 @@
 # Open Terms Archive - ops
 
-Where all transversal ops operation belongs
+Recipes to setup infrastructure and deploy Open Terms Archive proxy
+
+> Recettes pour mettre en place l'infrastructure et déployer le proxy nginx d'Open Terms Archive
+
+## Requirements
+
+- Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+- Install required Ansible roles `ansible-galaxy install -r requirements.yml`
+
+See [troubleshooting](#troubleshooting) in case of errors
+
+## Development
+
+In order to try out the infrastructure setup, we use virtual machines. We use [Vagrant](https://www.vagrantup.com) to describe and spawn these virtual machines with a simple `vagrant up` command.
+
+### Dependencies
+
+In order to automatically set up a virtual machine:
+
+1. Install [Vagrant](https://www.vagrantup.com/docs/installation/).
+2. Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) to manage virtual machines. If you prefer Docker, or have an Apple Silicon machine, install [Docker](https://docs.docker.com/get-docker/) instead.
+3. Create a dedicated SSH key with no password: `ssh-keygen -f ~/.ssh/ota-vagrant -q -N ""`. This key will be automatically used by Vagrant.
+
+> VirtualBox is not compatible with Apple Silicon (M1…) processors. If you have such a machine, you will need to use the Docker provider. Since MongoDB cannot be installed on ARM, it is skipped in the infrastructure installation process. This means you cannot test the MongoDB storage repository with Vagrant with an Apple Silicon processor.
+
+## Configuration
+
+### [For developement only] Configure your host machine to access the VM.
+
+Edit your hosts file `/etc/hosts`, add the following line so you can connect to the VM to test deployed apps from your host machine's browser:
+
+```
+192.168.33.12    ota.local
+```
+
+Now on your browser you will be able to access deployed app on the VM with the URL `http://ota.local` to mimic the real architecture of our servers
+
+The guest VM's IPs can be changed in the `VagrantFile`:
+
+## Usage
+
+To avoid making changes on the production server by mistake, by default all commands will only affect the vagrant developement VM. Note that the VM needs to be started before with `vagrant up`.\
+To execute commands on the production server you should specify it by adding the option `-i inventories/production.yml` to the following commands.
+
+- **Setup a phoenix server:**
+
+```
+ansible-playbook site.yml
+```
+
+- **Setup infrastructure only:**
+
+```
+ansible-playbook infra.yml
+```
+
+- **Setup apps only:**
+
+```
+ansible-playbook apps.yml
+```
+
+- **Setup one sub part of the infra:**
+
+```
+ansible-playbook playbooks/infra/<MODULE>.yml
+```
+
+_You can find all available modules in `playbooks/infra` directory._
+
+For example, to setup only nginx on the new server:
+
+```
+ansible-playbook playbooks/infra/nginx.yml
+```
+
+### Options
+
+Ansible provide among many others the following useful options:
+
+- `--diff`: to see what changed.
+- `--check`: to simulate execution.
+- `--check --diff`: to see what will be changed.
+
+For example, if you modify the nginx config and you want to see what will be changed you can run:
+
+```
+ansible-playbook playbooks/infra/nginx.yml --check --diff
+```
+
+### Sample commands
+
+In order to deploy here are the corresponding commands
+
+#### for vagrant
+
+```bash
+# Deploy site
+ansible-playbook playbooks/site.yml
+
+# Deploy all infra only
+ansible-playbook playbooks/infra.yml
+
+# Deploy only docker
+ansible-playbook playbooks/infra/docker.yml
+```
+
+#### for production 
+
+```bash
+# Check deployment of whole site
+ansible-playbook playbooks/site.yml -i inventories/production.yml --check --diff
+
+# Deploy whole site
+ansible-playbook playbooks/site.yml -i inventories/production.yml
+```
+## Troubleshooting
+
+### Failed to connect to the host via ssh: Received disconnect from 127.0.0.1 port 2222:2: Too many authentication failures
+
+Modify ansible ssh options to the `inventories/dev.yml` file like this:
+
+```
+all:
+  children:
+    dev:
+      hosts:
+        '127.0.0.1':
+          […]
+          ansible_ssh_private_key_file: .vagrant/machines/default/virtualbox/private_key
+          ansible_ssh_extra_args: -o StrictHostKeyChecking=no -o IdentitiesOnly=yes
+          […]
+```
+
+Or alternatively you can use the dev-fix config by appending `-i ops/inventories/dev-fix.yml`
+
+### ansible: command not found
+
+if you're on mac OSX and tried to install with `pip install ansible`
+you may need to add python's bin folder to your path with
+
+```
+export PATH=$PATH:/Users/<yourusername>/Library/Python/3.7/bin
+```
+
+### ~/.netrc access too permissive: access permissions must restrict access to only the owner
+
+on linux
+
+```
+chmod og-rw /home/<yourusername>/.netrc
+```
+
+on mac OSX
+
+```
+chmod og-rw /Users/<yourusername>/.netrc
+```
+
+### <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (\_ssl.c:1123)>
+
+on mac OSX, go to folder `/Applications/Python 3.9` and double click on `Install Certificates.command`
+
+### An error occurred during the signature verification. GPG error
+
+```
+# https://www.linuxuprising.com/2019/06/fix-missing-gpg-key-apt-repository.html
+
+sudo apt update 2>&1 1>/dev/null | sed -ne 's/.*NO_PUBKEY //p' | while read key; do if ! [[ ${keys[*]} =~ "$key" ]]; then sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys "$key"; keys+=("$key"); fi; done
+sudo apt update 2>&1 1>/dev/null | sed -ne 's/.*NO_PUBKEY //p' | while read key; do if ! [[ ${keys[*]} =~ "$key" ]]; then sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key"; keys+=("$key"); fi; done
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.hostname = "vagrant"
+
+  config.vm.box = "debian/bullseye64"
+
+  # in order to have the same config for both Docker and VirtualBox providers, we load the key manually
+  # if necessary, create the key with `ssh-keygen -f ~/.ssh/ota-vagrant -q -N ""`
+  # CAUTION: use of `~` in path causes problems with ssh
+  config.vm.provision "file", source: File.join(ENV['HOME'], ".ssh", "ota-vagrant.pub"), destination: "/home/vagrant/.ssh/authorized_keys"
+
+  # based on https://github.com/rofrano/vagrant-docker-provider#example-vagrantfile
+  config.vm.provider :docker do |docker, override|
+    override.vm.box = nil
+    docker.image = "rofrano/vagrant-provider:debian"
+    docker.remains_running = true
+    docker.has_ssh = true
+    docker.privileged = true
+    docker.volumes = ["/sys/fs/cgroup:/sys/fs/cgroup:rw"]
+    docker.create_args = ["--cgroupns=host"]
+
+    # python is not installed by default in the vagrant-provider image
+    # and deploying results in  /bin/sh: 1: /usr/bin/python: not found
+    # use a provision to fix that
+    # only with debian, no need with ubuntu
+    # Also need to name the provisioner, so that it runs only once https://github.com/hashicorp/vagrant/issues/7685#issuecomment-308281283
+    config.vm.provision "install_python3", type: "shell", inline: $installPython3
+  end
+end
+
+$installPython3 = <<-SCRIPT
+echo Updating apt...
+sudo apt-get update --fix-missing # Needed to fix "No package matching 'chromium' is available"
+echo Installing python...
+sudo apt-get --assume-yes install python3 python3-pip
+SCRIPT

--- a/inventories/dev.yml
+++ b/inventories/dev.yml
@@ -1,0 +1,12 @@
+all:
+  vars:
+    ansible_user: vagrant
+  children:
+    dev:
+      hosts:
+        '127.0.0.1':
+          ansible_ssh_port: 2222
+          ansible_python_interpreter: /usr/bin/python3
+          ansible_ssh_private_key_file: ~/.ssh/ota-vagrant
+          base_url: http://ota.local
+

--- a/inventories/production.yml
+++ b/inventories/production.yml
@@ -1,0 +1,10 @@
+all:
+  children:
+    production:
+      hosts:
+        51.75.169.235:
+          ansible_user: debian
+          ansible_ssh_extra_args: -o StrictHostKeyChecking=no
+          ansible_python_interpreter: /usr/bin/python3
+          base_url: https://51.75.169.235
+          enable_https: true

--- a/playbooks/apps.yml
+++ b/playbooks/apps.yml
@@ -1,0 +1,6 @@
+---
+- name: Setup OpenTermsArchive apps
+  hosts: all
+  become: yes
+
+- import_playbook: apps/proxy.yml

--- a/playbooks/apps/proxy.yml
+++ b/playbooks/apps/proxy.yml
@@ -1,0 +1,7 @@
+---
+- name: proxy
+  hosts: all
+  become: yes
+
+  roles:
+    - roles/apps/proxy

--- a/playbooks/infra.yml
+++ b/playbooks/infra.yml
@@ -1,0 +1,7 @@
+---
+- name: Setup OpenTermsArchive infrastructure
+  hosts: all
+  become: yes
+  
+- import_playbook: infra/common.yml
+- import_playbook: infra/nginx.yml

--- a/playbooks/infra/common.yml
+++ b/playbooks/infra/common.yml
@@ -1,0 +1,7 @@
+---
+- name: Common
+  hosts: all
+  become: yes
+
+  roles:
+    - roles/infra/common

--- a/playbooks/infra/docker.yml
+++ b/playbooks/infra/docker.yml
@@ -1,0 +1,7 @@
+---
+- name: Docker
+  hosts: all
+  become: yes
+
+  roles:
+    - roles/infra/docker

--- a/playbooks/infra/nginx.yml
+++ b/playbooks/infra/nginx.yml
@@ -1,0 +1,7 @@
+---
+- name: Nginx
+  hosts: all
+  become: yes
+
+  roles:
+    - roles/infra/nginx

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,0 +1,6 @@
+---
+- name: Setup Open Terms Archive infra and apps
+  hosts: all
+
+- import_playbook: infra.yml
+- import_playbook: apps.yml

--- a/roles/apps/proxy/handlers/main.yml
+++ b/roles/apps/proxy/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted

--- a/roles/apps/proxy/tasks/main.yml
+++ b/roles/apps/proxy/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Add ota conf in sites-available
+  template:
+    src: ota.tpl
+    dest: /etc/nginx/sites-available/ota
+    force: yes
+  notify: restart nginx
+
+- name: Link ota conf from sites-available to sites-enabled
+  file:
+    src: /etc/nginx/sites-available/ota
+    dest: /etc/nginx/sites-enabled/ota
+    state: link
+    force: yes
+  notify: restart nginx

--- a/roles/apps/proxy/templates/ota.tpl
+++ b/roles/apps/proxy/templates/ota.tpl
@@ -1,0 +1,67 @@
+# To add a subdomain
+# 1. create a server > location entry
+# 2. point the subdomain DNS to this server
+# 3. launch > sudo certbot --nginx -d subdomain.opentermsarchive.org
+# 4. Copy content of /etc/nginx/sites-available/ota to `OpenTermsArchive/ops/roles/infra/nginx/templates/ota.tpl`
+
+proxy_cache_path /dev/shm/nginx-ota levels=1:2 keys_zone=ota_cache:10m max_size=1g inactive=1m use_temp_path=off;
+
+server {
+  server_name contribute.opentermsarchive.org;
+
+  location /health-check {
+    add_header Content-Type text/plain always;
+    return 200 'contribute.opentermsarchive.org up and running!';
+  }
+
+  location / {
+    proxy_pass http://51.75.169.235:7023$request_uri;
+  }
+
+  listen 443 ssl; # managed by Certbot
+  ssl_certificate /etc/letsencrypt/live/contribute.opentermsarchive.org/fullchain.pem; # managed by Certbot
+  ssl_certificate_key /etc/letsencrypt/live/contribute.opentermsarchive.org/privkey.pem; # managed by Certbot
+  include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+server {
+  server_name contribute.preprod.opentermsarchive.org;
+
+  location /health-check {
+    add_header Content-Type text/plain always;
+    return 200 'contribute.preprod.opentermsarchive.org up and running!';
+  }
+
+  location / {
+    proxy_pass http://51.75.169.235:7024$request_uri;
+  }
+
+  listen 443 ssl; # managed by Certbot
+  ssl_certificate /etc/letsencrypt/live/contribute.preprod.opentermsarchive.org/fullchain.pem; # managed by Certbot
+  ssl_certificate_key /etc/letsencrypt/live/contribute.preprod.opentermsarchive.org/privkey.pem; # managed by Certbot
+  include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+}
+
+server {
+  if ($host = contribute.opentermsarchive.org) {
+      return 301 https://$host$request_uri;
+  } # managed by Certbot
+
+
+  server_name contribute.opentermsarchive.org;
+  listen 80;
+  return 404; # managed by Certbot
+}
+
+server {
+  if ($host = contribute.preprod.opentermsarchive.org) {
+      return 301 https://$host$request_uri;
+  } # managed by Certbot
+
+
+  server_name contribute.preprod.opentermsarchive.org;
+  listen 80;
+  return 404; # managed by Certbot
+}

--- a/roles/infra/common/tasks/main.yml
+++ b/roles/infra/common/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install common required packages
+  apt:
+    pkg:
+    - build-essential
+    - nano
+    - telnet
+    update_cache: yes
+    state: latest

--- a/roles/infra/docker/handlers/main.yml
+++ b/roles/infra/docker/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart docker
+  service:
+    name: docker
+    state: restarted

--- a/roles/infra/docker/tasks/main.yml
+++ b/roles/infra/docker/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Install docker dependencies
+  apt:
+    name: "{{item}}"
+    state: present
+    update_cache: yes
+  loop:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - gnupg-agent
+    - software-properties-common
+
+- name: add docker GPG key
+  apt_key:
+    url: https://download.docker.com/linux/debian/gpg
+    state: present
+
+- name: add docker repository to apt
+  apt_repository:
+    repo: deb https://download.docker.com/linux/debian buster stable
+    state: present
+
+- name: install docker
+  apt:
+    name: "{{item}}"
+    state: latest
+    update_cache: yes
+  loop:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+    - python3
+    - python-docker
+
+- name: Install docker with pip
+  pip:
+    name: docker
+
+- name: Install docker-compose with pip
+  pip:
+    name: docker-compose
+
+- name: Assure that docker is started
+  service:
+    name: docker
+    state: started
+    enabled: yes

--- a/roles/infra/nginx/handlers/main.yml
+++ b/roles/infra/nginx/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted

--- a/roles/infra/nginx/tasks/main.yml
+++ b/roles/infra/nginx/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Install needed packages
+  apt:
+    pkg:
+    - nginx
+    - cron
+    update_cache: yes
+    state: latest
+
+- name: Setup nginx conf
+  template:
+    src: nginx.conf.tpl
+    dest: /etc/nginx/nginx.conf
+  notify: restart nginx
+
+- name: Clean default conf from sites-enabled
+  file:
+    state: absent
+    path: /etc/nginx/sites-enabled/default
+  notify: restart nginx
+
+- name: Ensure a job that certificates are renewed every day."
+  ansible.builtin.cron:
+    name: "renew certificates"
+    minute: "10"
+    hour: "5"
+    job: "certbot renew --no-random-sleep-on-renew --nginx --nginx-ctl /usr/sbin/nginx --nginx-server-root /etc/nginx/"
+  become: yes

--- a/roles/infra/nginx/templates/nginx.conf.tpl
+++ b/roles/infra/nginx/templates/nginx.conf.tpl
@@ -1,0 +1,85 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 768;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+#
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+#
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+#
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}


### PR DESCRIPTION
As OTA has to be split from ambanum's repositories, here is a PR to move all existing ops files concerning ota from disinfo-ops to OpenTermsArchive organization.

Files are coming from https://github.com/ambanum/disinfo.quaidorsay.fr-ops/pull/4

The given files are a simple copy from the disinfo ops, and does not work for now on a phoenix server (This is because I made some changes directly on the server as I did not know how to use ansible)

I will propose a new PR soon that will make ops completely working without human interaction on the server.

This is part of fixing https://github.com/orgs/ambanum/projects/3/views/4, so that we can update server to debian bullseye
